### PR TITLE
fix rustup install line

### DIFF
--- a/src/002-installing-the-compiler.md
+++ b/src/002-installing-the-compiler.md
@@ -20,7 +20,7 @@ is sufficient to install the official Rust `nightly` compiler, as well as the `r
 Then install the `nightly` and `rust-src` components by running this in a terminal:
 
 ```
-$ rustup component add nightly rust-src
+$ rustup component add rust-src --toolchain nightly
 ```
 
 Installation complete. You can proceed to the next part [3. Building a crate for AVR](./003-building-a-crate-for-avr.md).


### PR DESCRIPTION
AFAIK `rustup component add nightly rust-src` will fail, this is the correct way to specify the toolchain