### PR TITLE
Describe how to flash an Arduino Uno with avrdude

### DIFF
--- a/src/002.1-installing-required-third-party-tools.md
+++ b/src/002.1-installing-required-third-party-tools.md
@@ -6,6 +6,7 @@ A number of third party tools are required to use AVR Rust.
 * avr-gcc (only used as a linker frontend)
 * avr-binutils (for linker support)
 * avr-libc (for device-specific runtime libraries)
+* avrdude (for flashing a real AVR chip)
 
 These should be installed by the operating system package manager.
 
@@ -14,7 +15,7 @@ These should be installed by the operating system package manager.
 To install all required dependencies under Arch Linux, run
 
 ```bash
-sudo pacman -S avr-gcc avr-libc
+sudo pacman -S avr-gcc avr-libc avrdude
 ```
 
 ## Ubuntu
@@ -22,7 +23,7 @@ sudo pacman -S avr-gcc avr-libc
 To install all required dependencies under Ubuntu Linux, run
 
 ```bash
-sudo apt-get install binutils gcc-avr avr-libc
+sudo apt-get install binutils gcc-avr avr-libc avrdude
 ```
 
 ## macOS
@@ -30,7 +31,9 @@ sudo apt-get install binutils gcc-avr avr-libc
 Set up the [homebrew-avr][] tap, then install the packages:
 
 ```bash
-brew install avr-binutils avr-gcc
+brew install avr-binutils avr-gcc avrdude
 ```
+
+Note that `avrdude` may be installed without the homebrew-avr tap.
 
 [homebrew-avr]: https://github.com/osx-cross/homebrew-avr

--- a/src/004-flashing-a-crate-to-chip.md
+++ b/src/004-flashing-a-crate-to-chip.md
@@ -8,4 +8,21 @@ Flashing a Rust ELF file is no different to flashing a regular AVR-GCC C/C++ gen
 * [AVRDUDE Project Homepage](https://www.nongnu.org/avrdude/)
 * [LadyADA AVRDUDE Tutorial](http://ladyada.net/learn/avr/avrdude.html)
 
-Better instructions, including an example showing the flashing of the LED blink program to an Arduino UNO, will be added to this guide in the future.
+## Arduino Uno
+
+Connect your Arduino Uno to your computer, and use `avrdude` to flash your crate. The example below uses the output from [the `blink` example](./003.2-example-building-blink.md).
+
+```bash
+avrdude -patmega328p -carduino -P[PORT] -b115200 -D -Uflash:w:target/avr-atmega328p/release/blink.elf:e
+```
+
+where
+* `-patmega328p` is the AVR part number
+* `-carduino` is the programmer
+* `-P[PORT]` is the serial port of your connected Arduino
+    * On Linux & macOS, replace `[PORT]` with your Arduino's serial port (like `/dev/ttyUSB0`)
+* `-b115200` is the baud rate
+* `-D` disables flash auto-erase
+* `-Uflash:w:target/avr-atmega328p/release/blink.elf:e` writes the `blink.elf` program to the Arduino's flash memory
+
+For more debugging information, run `avrdude` with one or more `-v` flags.


### PR DESCRIPTION
The PR proposes flashing documentation. The documentation now describes how flash the blink example to an Arduino Uno.

We scatter `avrdude` installation instructions throughout the third-party tools section. Tested the two Linux installations in some VMs, and tested the macOS installation with `brew`.

The `avrdude` usage is similar to how the Arduino IDE flashes a sketch. We skip one step: the IDE first uses `avr-objcopy` to convert ELF -> Intel hex. But, `avrdude` supports ELF files (at least as of version 6.3, from around 2016). The documentation shows how to use the ELF file directly, rather than first converting to hex. It doesn't seem to matter if I first convert to hex, then flash, vs directly flashing the ELF output; `avrdude` reports that it's flashing the same number of bytes in either usage.

Tested flashing on macOS. Should work on Linux, but untested.