### PR TITLE
Add command to install the nightly toolchain

### DIFF
--- a/src/002-installing-the-compiler.md
+++ b/src/002-installing-the-compiler.md
@@ -20,6 +20,8 @@ is sufficient to install the official Rust `nightly` compiler, as well as the `r
 Then install the `nightly` and `rust-src` components by running this in a terminal:
 
 ```
+$ rustup toolchain install nightly
+...
 $ rustup component add rust-src --toolchain nightly
 ```
 


### PR DESCRIPTION
Existing command to add component fails if nightly isn't already installed:

```
$ rustup component add rust-src --toolchain nightly
error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed 
```