### PR TITLE
Add Fedora dependency installation instructions

### DIFF
--- a/src/002.1-installing-required-third-party-tools.md
+++ b/src/002.1-installing-required-third-party-tools.md
@@ -18,6 +18,14 @@ To install all required dependencies under Arch Linux, run
 sudo pacman -S avr-gcc avr-libc avrdude
 ```
 
+## Fedora
+
+To install all required dependencies under Fedora Linux, run
+
+```bash
+sudo dnf install avr-gcc avr-libc avrdude
+```
+
 ## Ubuntu
 
 To install all required dependencies under Ubuntu Linux, run


### PR DESCRIPTION
I've added the missing Fedora dependency installation instructions. This also installs `avr-binutils`.