### PR TITLE
Fix typos

### DIFF
--- a/src/003-building-a-crate-for-avr.md
+++ b/src/003-building-a-crate-for-avr.md
@@ -17,7 +17,7 @@ In summary, there are two options:
 
   * Use `rustc --target=avr-unknown-gnu-atmega328` to use the default, builtin GCC based target for ATmega328
   * Or use `rustc --target=my-custom-avr-target.json` with either a JSON file adapted from the builtin
-      `avr-unknown-gnu-atmega328` target above, or otherwise build the file manually you wish to avoiding the
+      `avr-unknown-gnu-atmega328` target above, or otherwise build the file you wish manually to avoid the
       default path entirely.
 
 ## Make sure you use the nightly version of Rust, not the default stable channel
@@ -43,7 +43,7 @@ Using a custom target specification JSON:
 cargo build -Z build-std=core --target /path/to/my-custom-avr-target.json --release
 ```
 
-Either or these generate an AVR ELF file that can be subsequently flashed to a real device or ran inside a simulator.
+Either of these generate an AVR ELF file that can be subsequently flashed to a real device or ran inside a simulator.
 The ELF file will be available at `target/<TARGET NAME>/release/<CRATE NAME>.elf`.
 
 Notes:

--- a/src/003.1-the-avr-unknown-gnu-atmega328-target.md
+++ b/src/003.1-the-avr-unknown-gnu-atmega328-target.md
@@ -4,7 +4,7 @@ The Rust nightly compiler contains a built-in target, `avr-unknown-gnu-atmega328
 generates code for the AVR [ATmega328](https://en.wikipedia.org/wiki/ATmega328) using the
 GNU AVR-GCC toolchain for linking support.
 
-## Targeting custom microcontrollers by adapting 'avr-unkonwn-gnu-atmega328'
+## Targeting custom microcontrollers by adapting 'avr-unknown-gnu-atmega328'
 
 See the section [5.1. The Target Specification JSON File](./005.1-the-target-specification-json-file.md) for
 more information about how Rust target specification JSON files work.

--- a/src/005-add-avr-support-to-crate.md
+++ b/src/005-add-avr-support-to-crate.md
@@ -1,4 +1,4 @@
-# 5.1. Summary of Steps
+# 5. Summary of Steps
 
 ## Initial target-independent steps for creating a new crate
 

--- a/src/005.1-the-target-specification-json-file.md
+++ b/src/005.1-the-target-specification-json-file.md
@@ -4,7 +4,7 @@ External resources:
 
   * [The Embedonomicon on custom targets](https://docs.rust-embedded.org/embedonomicon/custom-target.html)
   * [rust-lang RFC on target specification JSON files](https://rust-lang.github.io/rfcs/0131-target-specification.html)
-  * [Upstream Rust documentation on custom target specifiactions](https://doc.rust-lang.org/rustc/targets/custom.html) [outdated, `xargo` is no longer required]
+  * [Upstream Rust documentation on custom target specifications](https://doc.rust-lang.org/rustc/targets/custom.html) [outdated, `xargo` is no longer required]
 
 Rust provides a built-in list of target specifications that are viewable via `rustc --print target-list`. A custom target specification JSON file may
 be written to override and tweak various target-specific options, such as linker scripts, flags, and LLVM options.


### PR DESCRIPTION
003:
1. Fix a grammatical error. I am unsure whether this fix captures
the same meaning as the original text.
2. Fix Github issue #32

003.1: Fix "unkonwn" typo

005: Fix Github issue #34

005.1: Fix specifiactions typo